### PR TITLE
Add Jest setup and API route tests

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,0 +1,28 @@
+import { createMocks } from 'node-mocks-http'
+import indexHandler from '../pages/api/people/index'
+import personHandler from '../pages/api/people/[id]'
+
+describe('People API', () => {
+  test('GET /api/people returns list of 10 items', async () => {
+    const { req, res } = createMocks({ method: 'GET' })
+    await indexHandler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(200)
+    const data = JSON.parse(res._getData())
+    expect(Array.isArray(data)).toBe(true)
+    expect(data).toHaveLength(10)
+  })
+
+  test('GET /api/people/[id] with valid id returns 200', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: { id: '1' } })
+    await personHandler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(200)
+    const data = JSON.parse(res._getData())
+    expect(data.id).toBe('1')
+  })
+
+  test('GET /api/people/[id] with invalid id returns 404', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: { id: '999' } })
+    await personHandler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(404)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "latest",
@@ -15,6 +16,14 @@
     "@types/node": "^18.0.0",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "node-mocks-http": "^1.11.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest in `package.json`
- add a `yarn test` script
- add API route tests checking `/api/people` and `/api/people/[id]`

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f98c2f2608329ae512a2ae1ad6f32